### PR TITLE
fix: add aggregate rating to product schema

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -411,6 +411,13 @@ import Base from "@/layouts/Base.astro";
     "@context": "https://schema.org",
     "@type": "Product",
     "name": "GPT Breeze",
+    "aggregateRating": {
+      "@type": "AggregateRating",
+      "ratingValue": "5",
+      "ratingCount": "4",
+      "bestRating": "5",
+      "worstRating": "1"
+    },
     "review": [
       {
         "@type": "Review",


### PR DESCRIPTION
## Summary
- add an aggregateRating object to the Product JSON-LD schema on the homepage so Google can parse multiple reviews

## Testing
- npm run check *(fails: requires installing @astrojs/check and typescript interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5f57b45c83269685c9a4f7ed349d