### PR TITLE
Increase feature card height and make it content-flexible

### DIFF
--- a/src/styles/landing-pages.css
+++ b/src/styles/landing-pages.css
@@ -370,7 +370,8 @@ section {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 70vh;
+  min-height: 80vh;
+  height: auto;
 }
 
 .features-grid {


### PR DESCRIPTION
### Motivation
- Ensure feature section text fits inside each feature card by increasing the card height and making the container flexible so it grows with content.

### Description
- Update `src/styles/landing-pages.css` to replace the fixed `height: 70vh` on `.features-sbs` with `min-height: 80vh` and `height: auto` so cards have a larger minimum size and can expand for content.

### Testing
- Started the dev server with `npm run dev` and the site served successfully. 
- Captured a screenshot of the updated features section using a Playwright script which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6909220c832697c3cded9c636521)